### PR TITLE
python3.x 无法 保存json文件问题

### DIFF
--- a/ch05/5.1.1.py
+++ b/ch05/5.1.1.py
@@ -17,5 +17,5 @@ for mulu in soup.find_all(class_="mulu"):
             box_title = a.get('title')
             list.append({'href':href,'box_title':box_title})
         content.append({'title':h2_title,'content':list})
-with open('qiye.json','wb') as fp:
+with open('qiye.json','w') as fp:
     json.dump(content,fp=fp,indent=4)


### PR DESCRIPTION
json.dump 在python3.x 中的 `fp` 。打开方式需是： `w` 模式。不能是 `wb` 模式。